### PR TITLE
Optional way to parse .php files and display the result

### DIFF
--- a/library/eval/testing.php
+++ b/library/eval/testing.php
@@ -1,0 +1,32 @@
+<?php //eval
+
+
+    function display_php_result(){
+
+        $url = "http://graph.facebook.com/facebook";
+        $json = file_get_contents($url);
+        $response = json_decode($json);
+
+        $html = "";
+        $html.= title($response->name);
+        $html.= text($response->about);
+        $html.= aref($response->link);
+
+        return $html;
+    }
+
+    function title($str){
+        return "<h1> $str </h1>";
+    }
+
+    function text($str){
+        return "<p> $str </p>";
+    }
+
+    function aref($str){
+        return "<a href='$str'>$str</a>";
+    }
+
+//file must return for this to work
+return display_php_result();
+?>

--- a/renderers/PHP_EVAL.php
+++ b/renderers/PHP_EVAL.php
@@ -1,0 +1,9 @@
+<?php
+
+function PHP_EVAL($source,$path){
+    if(strpos($source, '<?php //eval')===0){
+        if($HTML = include($path)){
+            return $HTML;
+        }
+    }
+}

--- a/wiki.php
+++ b/wiki.php
@@ -3,8 +3,10 @@
 class Wiki
 {
     protected $_renderers = array(
-        'md' => 'Markdown',
-        'htm' => 'HTML', 'html' => 'HTML'
+        'md'    => 'Markdown',
+        'htm'   => 'HTML',
+        'html'  => 'HTML',
+        'php'   => 'PHP_EVAL'
     );
     protected $_ignore = "/^\..*|^CVS$/"; // Match dotfiles and CVS
 	protected $_force_unignore = false; // always show these files (false to disable)
@@ -104,7 +106,7 @@ class Wiki
 
         $html = false;
         if ($renderer) {
-            $html = $renderer($source);
+            $html = $renderer($source,$path);
         }
 
         return $this->_view('render', array(


### PR DESCRIPTION
This is a small change that will allow users to show the result (and source code) of php files by typing `<?php //eval` as a start tag

motivation: _I'm using your awesome mini wiki as a personal notebook but I also want a fast and easy way to dynamically generate pages._