### PR TITLE
Let the user choose the default page in the config.php

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -5,6 +5,9 @@
 // Custom name for your wiki:
 define('APP_NAME', 'My Wiki');
 
+// Set the filename of the automatic homepage here
+define('DEFAULT_FILE', 'index.md');
+
 // Custom path to your wiki's library:
 // define('LIBRARY', '/path/to/wiki/library');
 

--- a/index.php
+++ b/index.php
@@ -14,6 +14,10 @@ if(!defined('LIBRARY')) {
     define('LIBRARY', __DIR__ . DIRECTORY_SEPARATOR . 'library');
 }
 
+if(!defined('DEFAULT_FILE')) {
+    define('DEFAULT_FILE', 'index.md');
+}
+
 if(!defined('USE_PAGE_METADATA')) {
     define('USE_PAGE_METADATA', true);
 }

--- a/library/index.md
+++ b/library/index.md
@@ -27,6 +27,7 @@ Now, there are other Markdown-powered wikis out there, and I've tried some of th
   You don't have to use the `library` directory if you don't want to, you can configure Wikitten using
   the `config.php` file. Simply copy the `config.php.example` file found in the site root to `config.php`,
   and change the values of the constants defined inside.
+  If you want to use another file as the default page (for example README.md) set the filename in the `config.php` file with the `DEFAULT_FILE` setting.
 
 ### JSON Front Matter (meta data)
 

--- a/views/index.php
+++ b/views/index.php
@@ -1,4 +1,4 @@
 <h1>Welcome to Wikitten!</h1>
 <p>
-  You're looking at this page because you haven't created a <code><?php echo LIBRARY . DIRECTORY_SEPARATOR . 'index.md' ?></code> file yet.
+  You're looking at this page because you haven't created a <code><?php echo LIBRARY . DIRECTORY_SEPARATOR . DEFAULT_FILE ?></code> file yet.
 </p>

--- a/wiki.php
+++ b/wiki.php
@@ -327,8 +327,8 @@ class Wiki
         $page    = str_replace("###" . APP_DIR . "/", "", "###" . urldecode($request['path']));
 
         if (!$page) {
-            if (file_exists(LIBRARY . DIRECTORY_SEPARATOR . 'index.md')) {
-                return $this->_render('index.md');
+            if (file_exists(LIBRARY . DIRECTORY_SEPARATOR . DEFAULT_FILE)) {
+                return $this->_render(DEFAULT_FILE);
             }
 
             return $this->_view('index', array(


### PR DESCRIPTION
By default the `index.md` is used as the default page.
But now the user is able to set an own default page (e.g. README.md for GitHub repos) in the config.php which overrides the index.md