### PR TITLE
Render more Markdown extensions as Markdown

### DIFF
--- a/wiki.php
+++ b/wiki.php
@@ -3,7 +3,7 @@
 class Wiki
 {
     protected $_renderers = array(
-        'md' => 'Markdown',
+        'md' => 'Markdown', 'mdown' => 'Markdown', 'markdown' => 'Markdown',
         'htm' => 'HTML', 'html' => 'HTML'
     );
     protected $_ignore = "/^\..*|^CVS$/"; // Match dotfiles and CVS


### PR DESCRIPTION
This allows for `.markdown` and `.mdown` files to be rendered as Markdown too. I've seen both used occasionally (IIRC, at least one of them is accepted by Github as well, but I couldn't really say which, sorry).