### PR TITLE
Allow APP_DIR to be overridden cleanly in config

### DIFF
--- a/index.php
+++ b/index.php
@@ -44,18 +44,20 @@ if (!defined('PASTEBIN_API_KEY')) {
 
 define('PLUGINS', __DIR__ . DIRECTORY_SEPARATOR . 'plugins');
 
-$request_uri = parse_url($_SERVER['REQUEST_URI']);
-$request_uri = explode("/", $request_uri['path']);
-$script_name = explode("/", dirname($_SERVER['SCRIPT_NAME']));
+if (!defined('APP_DIR')) {
+    $request_uri = parse_url($_SERVER['REQUEST_URI']);
+    $request_uri = explode("/", $request_uri['path']);
+    $script_name = explode("/", dirname($_SERVER['SCRIPT_NAME']));
 
-$app_dir = array();
-foreach ($request_uri as $key => $value) {
-    if (isset($script_name[$key]) && $script_name[$key] == $value) {
-        $app_dir[] = $script_name[$key];
+    $app_dir = array();
+    foreach ($request_uri as $key => $value) {
+        if (isset($script_name[$key]) && $script_name[$key] == $value) {
+            $app_dir[] = $script_name[$key];
+        }
     }
-}
 
-define('APP_DIR', rtrim(implode('/', $app_dir), "/"));
+    define('APP_DIR', rtrim(implode('/', $app_dir), "/"));
+}
 
 $https = false;
 if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on") {


### PR DESCRIPTION
This is incredibly minor, but in some odd configurations (such as having the PHP app root outside of the public_html root) one might need to override APP_DIR. Instead of undefining and then defining it again, this allows the definition to occur only once.

As I said, it's so minor that it's probably already taken you more time to read this than to change it. Sorry for that.